### PR TITLE
Indicate response body if delivery request is not successful

### DIFF
--- a/lib/ses_api/rails/api.rb
+++ b/lib/ses_api/rails/api.rb
@@ -39,8 +39,8 @@ module SesApi
           end
           req.headers['Authorization'] = create_auth_header(dt, credential_scope, hashed_payload, headers)
         end
-      
-        raise SesApi::Rails::SesError if response.status != 200
+
+        raise SesApi::Rails::SesError, response.body if response.status != 200
       end
 
       def create_datetime


### PR DESCRIPTION
When running into issue with un-successful deliveries I found that the issue was much clearer when indicating the response body, along with the exception.
